### PR TITLE
fix: change talos-systems mentions to siderolabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/skyzyx/asdf-conform.svg?branch=master)](https://travis-ci.org/skyzyx/asdf-conform)
 
-[Conform](https://github.com/talos-systems/conform) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.
+[Conform](https://github.com/siderolabs/conform) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.
 
 ## Install
 

--- a/bin/install
+++ b/bin/install
@@ -10,7 +10,7 @@ set \
 : ${ASDF_INSTALL_VERSION?}
 : ${ASDF_INSTALL_PATH?}
 
-github_coordinates=talos-systems/conform
+github_coordinates=siderolabs/conform
 
 install_tool() {
   #local install_type=$1
@@ -64,7 +64,7 @@ get_filename() {
   echo "${binary_name}-${platform}"
 }
 
-# https://github.com/talos-systems/conform/releases/download/v0.1.0-alpha.16/conform-darwin-amd64
+# https://github.com/siderolabs/conform/releases/download/v0.1.0-alpha.16/conform-darwin-amd64
 
 get_download_url() {
   local version="$1"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-github_coordinates=talos-systems/conform
+github_coordinates=siderolabs/conform
 releases_path="https://api.github.com/repos/${github_coordinates}/releases"
 cmd="curl -sSL"
 if [ -n "$GITHUB_API_TOKEN" ]; then


### PR DESCRIPTION
Probably not that important since Github should be maintaining redirections, but the `conform` repo moved to https://github.com/siderolabs/conform.

The github repo description can be updated as well.